### PR TITLE
Depend on boost directly instead of expecting to get it transitively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(gpg)
 set(CMAKE_BUILD_TYPE Release)
 
@@ -10,6 +10,9 @@ find_package(PCL REQUIRED)
 include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
+
+# Boost
+find_package(Boost REQUIRED COMPONENTS thread)
 
 ## Set compiler optimization flags
 set(CMAKE_CXX_FLAGS "-O3 -fopenmp -fPIC -Wno-deprecated -Wenum-compare")
@@ -30,10 +33,14 @@ add_library(${PROJECT_NAME}_eigen_utils src/${PROJECT_NAME}/eigen_utils.cpp)
 add_library(${PROJECT_NAME}_finger_hand src/${PROJECT_NAME}/finger_hand.cpp)
 add_library(${PROJECT_NAME}_frame_estimator src/${PROJECT_NAME}/frame_estimator.cpp)
 add_library(${PROJECT_NAME}_grasp src/${PROJECT_NAME}/grasp.cpp)
+target_link_libraries(${PROJECT_NAME}_grasp Boost::headers)
 add_library(${PROJECT_NAME}_grasp_set src/${PROJECT_NAME}/grasp_set.cpp)
+target_link_libraries(${PROJECT_NAME}_grasp_set Boost::headers)
 add_library(${PROJECT_NAME}_hand_search src/${PROJECT_NAME}/hand_search.cpp)
 add_library(${PROJECT_NAME}_local_frame src/${PROJECT_NAME}/local_frame.cpp)
+target_link_libraries(${PROJECT_NAME}_local_frame Boost::headers)
 add_library(${PROJECT_NAME}_plot src/${PROJECT_NAME}/plot.cpp)
+target_link_libraries(${PROJECT_NAME}_plot Boost::thread Boost::headers)
 add_library(${PROJECT_NAME}_point_list src/${PROJECT_NAME}/point_list.cpp)
 
 # This executable is for testing the shared library

--- a/src/gpg/plot.cpp
+++ b/src/gpg/plot.cpp
@@ -1,5 +1,9 @@
 #include <gpg/plot.h>
 
+#include <boost/lexical_cast.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
+
 
 void Plot::plotFingers(const std::vector<GraspSet>& hand_set_list, const PointCloudRGBA::Ptr& cloud,
   std::string str, double outer_diameter) const


### PR DESCRIPTION
This fixes a compile error on Ubuntu Focal. The target building `plot.cpp` fails because `boost::this_thread` is used but not defined. I think what happened is the version of PCL on Bionic depends on Boost, but the version on Focal does not so `gpg_modified` can't expect to get it transitively on Focal. This PR adds missing includes for Boost headers, and adds a `find_package(Boost ...)` for building with CMake.